### PR TITLE
Updates for v1.0-isms

### DIFF
--- a/v1.0/lasertools.inx
+++ b/v1.0/lasertools.inx
@@ -2,7 +2,7 @@
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
     <_name>Lasertools</_name>
     <id>org.lasertools.lasertools</id>
-	<dependency type="executable" location="extensions">lasertools.py</dependency>
+	<dependency type="executable" location="inx">lasertools.py</dependency>
 	<param name='active-tab' type="notebook">
 
 		<page name='lastertools' _gui-text='Lasertools'>	
@@ -50,7 +50,7 @@
   	</effect>
 
 	<script>
-		<command reldir="extensions" interpreter="python">lasertools.py</command>
+		<command location="inx" interpreter="python">lasertools.py</command>
 	</script>
 
 </inkscape-extension>


### PR DESCRIPTION
https://wiki.inkscape.org/wiki/index.php/Updating_your_Extension_for_1.0

1. "The old parameter reldir is deprecated."
2. For easier extension 'installation' by users and for having a better overview about the installed extensions, you can now put extensions into their own subfolders of the extensions directory.

